### PR TITLE
Methods with the same name as their class are deprecated

### DIFF
--- a/class-php-ico.php
+++ b/class-php-ico.php
@@ -34,7 +34,7 @@ class PHP_ICO {
 	 * @param string $file Optional. Path to the source image file.
 	 * @param array $sizes Optional. An array of sizes (each size is an array with a width and height) that the source image should be rendered at in the generated ICO file. If sizes are not supplied, the size of the source image will be used.
 	 */
-	function PHP_ICO( $file = false, $sizes = array() ) {
+	function __construct( $file = false, $sizes = array() ) {
 		$required_functions = array(
 			'getimagesize',
 			'imagecreatefromstring',


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP; PHP_ICO has a deprecated constructor